### PR TITLE
Update README.md hardware section

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,8 @@ The android application is developed using an object oriented approach by applyi
 
 ### Hardware used:
 - Arduino
-- ESP32 microcontroller
-- SmartCar shield
-- Wi-Fi adapter/transceiver 
+- [Smartcar platform](https://www.hackster.io/platisd/getting-started-with-the-smartcar-platform-1648ad) based on the ESP32 microcontroller
+- Wi-Fi and Bluetooth connectivity (integrated in the ESP32 SoC microcontroller)
 - GPS sensor
 - 3D-printer
 


### PR DESCRIPTION
Remove the SmartCar shield reference, driven by the discussion on #7172c7d, as well as adjust the wording about the Wi-Fi and Bluetooth connectivity.

As noted in the Smartcar documentation pages, the latest version of the platform is based on the ESP32 microcontroller (referred to as platform or v2), instead of the previous setup that was based on the Smartcar shield that was used on top of an arduino (referred to as shield or v1).