### PR TITLE
Smartcar logic improvements

### DIFF
--- a/app/src/main/java/se/healthrover/car_service/CarManagement.java
+++ b/app/src/main/java/se/healthrover/car_service/CarManagement.java
@@ -6,5 +6,5 @@ import se.healthrover.entities.HealthRoverCar;
 public interface CarManagement {
 
     void checkStatus(HealthRoverCar healthRoverCar, Activity activity);
-    void moveCar(HealthRoverCar healthRoverCar, int speed, int angle, Activity activity);
+    void moveCar(HealthRoverCar healthRoverCar, int speed, int angle, String controlType, Activity activity);
 }

--- a/app/src/main/java/se/healthrover/car_service/CarManagementImp.java
+++ b/app/src/main/java/se/healthrover/car_service/CarManagementImp.java
@@ -21,8 +21,8 @@ public class CarManagementImp implements CarManagement {
         webService.createHttpRequest(request, activity);
     }
 
-    public void moveCar(HealthRoverCar healthRoverCar, int speed, int angle, Activity activity) {
-        String request = healthRoverCar.getUrl() + CarCommands.REQUEST.getCarCommands() + CarCommands.SPEED.getCarCommands() + speed + CarCommands.ANGLE.getCarCommands() + angle;
+    public void moveCar(HealthRoverCar healthRoverCar, int speed, int angle, String controlType, Activity activity) {
+        String request = healthRoverCar.getUrl() + CarCommands.REQUEST.getCarCommands() + CarCommands.SPEED.getCarCommands() + speed + CarCommands.ANGLE.getCarCommands() + angle + CarCommands.CONTROL.getCarCommands() + controlType;
         webService.createHttpRequest(request, activity );
     }
 }

--- a/app/src/main/java/se/healthrover/entities/CarCommands.java
+++ b/app/src/main/java/se/healthrover/entities/CarCommands.java
@@ -3,7 +3,7 @@ package se.healthrover.entities;
 public enum CarCommands {
 
     //A list of predefined commands used to manage the Smartcar.
-    ANGLE("&angle="), STATUS("status"), SPEED("&speed="), REQUEST("request?type=move"),
+    ANGLE("&angle="), STATUS("status"), SPEED("&speed="), REQUEST("request?type=move"), CONTROL("&control="),
 
     //A list of predefined constant values for the SmartCar.
     NO_ANGLE("0"), NO_MOVEMENT("0"), VC_MAX_VELOCITY("50"), VC_MIN_VELOCITY("10"), DEFAULT_ANGLE("90");

--- a/app/src/main/java/se/healthrover/ui_activity_controller/ManualControl.java
+++ b/app/src/main/java/se/healthrover/ui_activity_controller/ManualControl.java
@@ -31,6 +31,7 @@ public class ManualControl extends AppCompatActivity {
     private HealthRoverCar healthRoverCar;
     private HealthRoverJoystick healthRoverJoystick;
     private static final int JOYSTICK_CENTER = 50;
+    private static final String CONTROL_TYPE = "manual";
     // Can be used to reduce number of request send (1 of 4 blocks of code)
     // private int[] lastSpeedAndAngleValues;
 
@@ -91,7 +92,7 @@ public class ManualControl extends AppCompatActivity {
                     turningAngle = 0;
                 }
                 //If reduce request is used this statement needs to be moved inside the if statement above (4 of 4 blocks of code)
-                carManagement.moveCar(healthRoverCar, speed, turningAngle, ManualControl.this);
+                carManagement.moveCar(healthRoverCar, speed, turningAngle, CONTROL_TYPE, ManualControl.this);
 
                 //Update the UI speed and angle
                 angleText.setText(turningAngle + getString(R.string.degree_symbol));

--- a/app/src/main/java/se/healthrover/ui_activity_controller/error_handling/ActivityExceptionHandler.java
+++ b/app/src/main/java/se/healthrover/ui_activity_controller/error_handling/ActivityExceptionHandler.java
@@ -35,6 +35,7 @@ public class ActivityExceptionHandler implements Thread.UncaughtExceptionHandler
             carManagement.moveCar(healthRoverCar,
                 Integer.parseInt(CarCommands.NO_MOVEMENT.getCarCommands()),
                 Integer.parseInt(CarCommands.NO_ANGLE.getCarCommands()),
+                CarCommands.CONTROL.getCarCommands(),
                 activity);
         }
         // When the main page is loaded after application restart

--- a/app/src/main/java/se/healthrover/ui_activity_controller/voice_control/SpeechRecognition.java
+++ b/app/src/main/java/se/healthrover/ui_activity_controller/voice_control/SpeechRecognition.java
@@ -62,6 +62,7 @@ public class SpeechRecognition extends AppCompatActivity {
     private static final String DIALOGFLOW_DIRECTION_VALUE_DECREASE = "decrease";
     private static final String DIALOGFLOW_DIRECTION_VALUE_LEFT = "left";
     private static final String DIALOGFLOW_DIRECTION_VALUE_RIGHT = "right";
+    private static final String CONTROL_TYPE = "voice";
 
 
     //Create the activity
@@ -228,15 +229,15 @@ public class SpeechRecognition extends AppCompatActivity {
                 if (speed < SPEED_CHECK) {
                     speed = speed * NEGATION;
                 }
-                carManagement.moveCar(healthRoverCar, speed, Integer.parseInt(CarCommands.NO_ANGLE.getCarCommands()), this);
+                carManagement.moveCar(healthRoverCar, speed, Integer.parseInt(CarCommands.NO_ANGLE.getCarCommands()), CONTROL_TYPE, this);
                 break;
             case DIALOGFLOW_DIRECTION_VALUE_STOP:
-                carManagement.moveCar(healthRoverCar, Integer.parseInt(CarCommands.NO_MOVEMENT.getCarCommands()), Integer.parseInt(CarCommands.NO_ANGLE.getCarCommands()), this);
+                carManagement.moveCar(healthRoverCar, Integer.parseInt(CarCommands.NO_MOVEMENT.getCarCommands()), Integer.parseInt(CarCommands.NO_ANGLE.getCarCommands()), CONTROL_TYPE, this);
                 break;
             case DIALOGFLOW_DIRECTION_VALUE_INCREASE:
                 if (speed < Integer.parseInt(CarCommands.VC_MAX_VELOCITY.getCarCommands()) && speed > Integer.parseInt(CarCommands.VC_MIN_VELOCITY.getCarCommands())) {
                     speed += VELOCITY_MODIFIER;
-                    carManagement.moveCar(healthRoverCar, speed, Integer.parseInt(CarCommands.NO_ANGLE.getCarCommands()), this);
+                    carManagement.moveCar(healthRoverCar, speed, Integer.parseInt(CarCommands.NO_ANGLE.getCarCommands()), CONTROL_TYPE, this);
                 } else {
                     userInterfaceUtilities.showCustomToast(SpeechRecognition.this, getString(R.string.voice_control_max_velocity));
                 }
@@ -244,25 +245,25 @@ public class SpeechRecognition extends AppCompatActivity {
             case DIALOGFLOW_DIRECTION_VALUE_DECREASE:
                 if (speed > Integer.parseInt(CarCommands.VC_MIN_VELOCITY.getCarCommands())) {
                     speed -= VELOCITY_MODIFIER;
-                    carManagement.moveCar(healthRoverCar, speed, Integer.parseInt(CarCommands.NO_ANGLE.getCarCommands()), this);
+                    carManagement.moveCar(healthRoverCar, speed, Integer.parseInt(CarCommands.NO_ANGLE.getCarCommands()), CONTROL_TYPE, this);
                 } else {
                     userInterfaceUtilities.showCustomToast(SpeechRecognition.this, getString(R.string.voice_control_min_velocity));
                 }
                 break;
             case DIALOGFLOW_DIRECTION_VALUE_LEFT:
                 speed = receivedSpeed;
-                carManagement.moveCar(healthRoverCar, speed, (receivedAngle * NEGATION), this);
+                carManagement.moveCar(healthRoverCar, speed, (receivedAngle * NEGATION), CONTROL_TYPE, this);
                 break;
             case DIALOGFLOW_DIRECTION_VALUE_RIGHT:
                 speed = receivedSpeed;
-                carManagement.moveCar(healthRoverCar, speed, receivedAngle, this);
+                carManagement.moveCar(healthRoverCar, speed, receivedAngle, CONTROL_TYPE, this);
                 break;
             case DIALOGFLOW_DIRECTION_VALUE_REVERSE:
                 speed = receivedSpeed;
                 if(speed>SPEED_CHECK) {
                     speed = speed * NEGATION;
                 }
-                carManagement.moveCar(healthRoverCar, speed, Integer.parseInt(CarCommands.NO_ANGLE.getCarCommands()), this);
+                carManagement.moveCar(healthRoverCar, speed, Integer.parseInt(CarCommands.NO_ANGLE.getCarCommands()), CONTROL_TYPE, this);
                 break;
             default:
                 userInterfaceUtilities.showCustomToast(SpeechRecognition.this, getString(R.string.invalid_command));

--- a/app/src/main/java/se/healthrover/ui_activity_controller/voice_control/SpeechRecognition.java
+++ b/app/src/main/java/se/healthrover/ui_activity_controller/voice_control/SpeechRecognition.java
@@ -119,6 +119,7 @@ public class SpeechRecognition extends AppCompatActivity {
             public void onClick(View v) {
                 Intent speechIntent = ObjectFactory.getInstance().getIntent(RecognizerIntent.ACTION_RECOGNIZE_SPEECH);
                 speechIntent.putExtra(RecognizerIntent.EXTRA_LANGUAGE_MODEL, RecognizerIntent.LANGUAGE_MODEL_FREE_FORM);
+                speechIntent.putExtra(RecognizerIntent.EXTRA_LANGUAGE, "en-US");
                 speechIntent.putExtra(RecognizerIntent.EXTRA_PROMPT, getString(R.string.voice_pop_up_message));
                 startActivityForResult(speechIntent, SPEECH_RESULT);
             }
@@ -177,8 +178,6 @@ public class SpeechRecognition extends AppCompatActivity {
                 String receivedAngle = response.getQueryResult().getParameters().getFieldsOrThrow(DIALOGFLOW_RESPONSE_KEY_ANGLE).getStringValue();
                 // Taking only the integer value from the receivedAngle String which includes not used characters
                 receivedAngle = CharMatcher.inRange('0', '9').retainFrom(receivedAngle);
-
-                System.out.println(response.getQueryResult().getParameters().toString());
 
                 // Here we check for empty values to be able to call driveCarCommand with
                 // default values, otherwise it will use user-specified ones

--- a/app/src/test/java/se/healthrover/entities/CarManagementImpTest.java
+++ b/app/src/test/java/se/healthrover/entities/CarManagementImpTest.java
@@ -22,8 +22,8 @@ public class CarManagementImpTest {
 
     @Test
     public void checkIfRequestIsSendTest() {
-        carManagementSpy.moveCar(HealthRoverCar.HEALTH_ROVER_CAR1,0,0,null);
-        Mockito.verify(carManagementSpy, Mockito.times(1)).moveCar(HealthRoverCar.HEALTH_ROVER_CAR1,0,0,null);
+        carManagementSpy.moveCar(HealthRoverCar.HEALTH_ROVER_CAR1,0,0,"manual",null);
+        Mockito.verify(carManagementSpy, Mockito.times(1)).moveCar(HealthRoverCar.HEALTH_ROVER_CAR1,0,0, "manual",null);
     }
 
 

--- a/arduino/healthRover/healthRover.ino
+++ b/arduino/healthRover/healthRover.ino
@@ -2,7 +2,6 @@
 #include <Wire.h>
 #include <WiFi.h>
 #include <WebServer.h>
-#include <ESPmDNS.h>
 
 const auto pulsesPerMeter = 600;
 const int START_SPEED = 40;
@@ -63,10 +62,11 @@ void loop() {
   // Stop when distance from the front sensor is less than MIN_OBSTACLE_DISTANCE and
   // the car is moving forward,
   // disregard 0 reading because its a null reading from the sensor
-  if (frontSensorReading <= MIN_OBSTACLE_DISTANCE && frontSensorReading > 0 && carSpeed > 0){
+  if (frontSensorReading <= MIN_OBSTACLE_DISTANCE && frontSensorReading > 5 && carSpeed > 0){
     car.setSpeed(STOP);
+    server.send(200, "text/plain", "obstacle");
   }else if (WiFi.status() != WL_CONNECTED){
-    car.setSpeed(STOP);
+    //car.setSpeed(STOP);
     connectToWiFi();
   }
 }
@@ -159,7 +159,7 @@ void turnCar(int turningAngle) {
         // currentHeading)
         int degreesTurnedSoFar  = initialHeading - currentHeading;
         hasReachedTargetDegrees = smartcarlib::utils::getAbsolute(degreesTurnedSoFar)
-                                  >= smartcarlib::utils::getAbsolute(degrees);
+                                  >= smartcarlib::utils::getAbsolute(turningAngle);
     }
     setCarAngle(0);
 }
@@ -177,8 +177,8 @@ void handleRequest() {
     server.send(200);
   }
   else if (appRequest.equals("move") && controlRequest.equals("voice")) {
-      turnCar(angleRequest);
       setCarSpeed(speedRequest);
+      turnCar(angleRequest);
       server.send(200);
   }
   else if (appRequest.equals("stop")) {

--- a/arduino/healthRover/healthRover.ino
+++ b/arduino/healthRover/healthRover.ino
@@ -117,17 +117,69 @@ void setCarSpeed(int newSpeed){
     car.setSpeed(carSpeed);
   }
 }
+// Turns the car, on the spot, the specified degrees and then resets the car's angle
+// Adapted version from SmartCar Shield Library's automated movements example, as seen
+// in the link: https://platisd.github.io/smartcar_shield/automated_movements_8ino-example.html
+void turnCar(int turningAngle) {
+    turningAngle %= 360; // Put degrees in a (-360,360) scale
+    if (turningAngle == 0)
+    {
+        return;
+    }
+    if (turningAngle > 0)
+    {
+        setCarAngle(90);
+    }
+    else
+    {
+        setCarAngle(-90);
+    }
+    const auto initialHeading    = car.getHeading();
+    bool hasReachedTargetDegrees = false;
+    while (!hasReachedTargetDegrees)
+    {
+        car.update();
+        auto currentHeading = car.getHeading();
+        if (turningAngle < 0 && currentHeading > initialHeading)
+        {
+            // If we are turning left and the current heading is larger than the
+            // initial one (e.g. started at 10 degrees and now we are at 350), we need to subtract
+            // 360 so to eventually get a signed displacement from the initial heading (-20)
+            currentHeading -= 360;
+        }
+        else if (turningAngle > 0 && currentHeading < initialHeading)
+        {
+            // If we are turning right and the heading is smaller than the
+            // initial one (e.g. started at 350 degrees and now we are at 20), so to get a signed
+            // displacement (+30)
+            currentHeading += 360;
+        }
+        // Degrees turned so far is initial heading minus current (initial heading
+        // is at least 0 and at most 360. To handle the "edge" cases we subtracted or added 360 to
+        // currentHeading)
+        int degreesTurnedSoFar  = initialHeading - currentHeading;
+        hasReachedTargetDegrees = smartcarlib::utils::getAbsolute(degreesTurnedSoFar)
+                                  >= smartcarlib::utils::getAbsolute(degrees);
+    }
+    setCarAngle(0);
+}
 void handleRequest() {
-  if (!server.hasArg("type") && !server.hasArg("speed") && !server.hasArg("angle")) {
+  if (!server.hasArg("type") && !server.hasArg("speed") && !server.hasArg("angle") && !server.hasArg("control")) {
     server.send(404);
     return;
   }
   String appRequest = server.arg("type");
   int speedRequest = (server.arg("speed")).toInt();
   int angleRequest = (server.arg("angle")).toInt();
-  if (appRequest.equals("move")) {
+  String controlRequest = server.arg("control");
+  if (appRequest.equals("move") && controlRequest.equals("manual")) {
     setCarMovement(speedRequest, angleRequest);
     server.send(200);
+  }
+  else if (appRequest.equals("move") && controlRequest.equals("voice")) {
+      turnCar(angleRequest);
+      setCarSpeed(speedRequest);
+      server.send(200);
   }
   else if (appRequest.equals("stop")) {
     stopCar();

--- a/arduino/healthRover/healthRover.ino
+++ b/arduino/healthRover/healthRover.ino
@@ -59,9 +59,11 @@ void loop() {
   server.handleClient();
 
   frontSensorReading = front.getDistance();
-  // Stop when distance is less than MIN_OBSTACLE_DISTANCE and
+  // OBSTACLE AVOIDANCE
+  // Stop when distance from the front sensor is less than MIN_OBSTACLE_DISTANCE and
+  // the car is moving forward,
   // disregard 0 reading because its a null reading from the sensor
-  if (frontSensorReading <= MIN_OBSTACLE_DISTANCE && frontSensorReading > 0){
+  if (frontSensorReading <= MIN_OBSTACLE_DISTANCE && frontSensorReading > 0 && carSpeed > 0){
     car.setSpeed(STOP);
   }else if (WiFi.status() != WL_CONNECTED){
     car.setSpeed(STOP);


### PR DESCRIPTION
# Related issue
- Closes #51, closes #71 

# Proposed changes
- Allow reverse to be initiated when an obstacle has beed detected by the front sensor, which was previously prohibiting any movement at all.
- Update the format of the HTTP requests that are being sent to the car from the Android application to use an extra parameter (control type). This helps to track the mode of control (manual or voice) that sent the command to the car.
- Update the Arduino sketch to conform with the aforementioned HTTP request change.
- Implement different maneuvering behaviours into the Arduino sketch, whenever a request is sent with the respective control type. Specifically, when it comes from Voice Control mode, then a different method is being called that allows the SmartCar to rotate on spot.

# Additional information
- The two different control types that the requests send after that implementation would either be `manual` when the request was initiated from the Manual Control mode, whereas `voice` when it comes from Voice Control.
- Also an addition to the SpeechRecognition class has been included to specify the default language (English) for the Speech Recognition API, in order to get better results.
